### PR TITLE
Fix expired refresh token

### DIFF
--- a/fourinsight/api/authenticate.py
+++ b/fourinsight/api/authenticate.py
@@ -112,12 +112,12 @@ class BaseAuthSession(OAuth2Session, metaclass=ABCMeta):
 
         # Attention: Be careful when extending the list of retry_status!
         retry_status = frozenset([413, 429, 502, 503, 504])
-        method_allow = frozenset(["GET", "POST", "PUT", "PATCH", "DELETE"])
+        allowed_methods = frozenset(["GET", "POST", "PUT", "PATCH", "DELETE"])
 
         persist = Retry(
             total=3,
             backoff_factor=0.5,
-            method_whitelist=method_allow,
+            allowed_methods=allowed_methods,
             status_forcelist=retry_status,
             raise_on_status=False,
         )


### PR DESCRIPTION
Fix issue with not properly handling cases where refresh token is expired. Instead of triggering a new "fetch token" cycle, HTTP 400 was raised.

Issue turned out to be an premature "raise_for_status" in client_side code.

Changes:
* remove "raise_for_status"
* update "method_whitelist" with "allowed_methods" (due to deprecation warning)