### PR TITLE
Handle MissingTokenError when refreshing token

### DIFF
--- a/fourinsight/api/authenticate.py
+++ b/fourinsight/api/authenticate.py
@@ -12,6 +12,7 @@ except ImportError:
 from oauthlib.oauth2 import (
     BackendApplicationClient,
     InvalidGrantError,
+    MissingTokenError,
     WebApplicationClient,
 )
 from requests.adapters import HTTPAdapter
@@ -134,7 +135,7 @@ class BaseAuthSession(OAuth2Session, metaclass=ABCMeta):
         else:
             try:
                 token = self.refresh_token()
-            except (KeyError, ValueError, InvalidGrantError):
+            except (KeyError, ValueError, InvalidGrantError, MissingTokenError):
                 log.debug("not able to refresh token")
                 token = self.fetch_token()
             else:

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -32,7 +32,6 @@ def test_constants():
 @patch("fourinsight.api.authenticate.user_data_dir")
 class Test_TokenCache:
     def test_init_dir_doesnt_exists(self, mock_cache_dir, tmp_path):
-
         cache_dir = tmp_path / "cache_dir"
         mock_cache_dir.return_value = cache_dir
 
@@ -508,7 +507,6 @@ class Test_BaseAuthSession:
         assert log_out.startswith("request initiated")
 
     def test_get_pages(self, mock_fetch, mock_refresh):
-
         JSON_DATA = [
             {
                 "value": {"a": 0, "b": "foo", "c": "bar"},
@@ -561,7 +559,6 @@ class Test_BaseAuthSession:
             )
 
     def test_get_pages_last_nextlink_none(self, mock_fetch, mock_refresh):
-
         JSON_DATA = [
             {
                 "value": {"a": 0, "b": "foo", "c": "bar"},
@@ -615,7 +612,6 @@ class Test_BaseAuthSession:
             )
 
     def test_get_pages_raises_json_list(self, mock_fetch, mock_refresh):
-
         JSON_DATA = [
             {
                 "a": "foo",
@@ -643,7 +639,6 @@ class Test_BaseAuthSession:
                 next(pages)
 
     def test_get_pages_raise_for_status(self, mock_fetch, mock_refresh):
-
         JSON_DATA = [
             {
                 "value": {"a": 0, "b": "foo", "c": "bar"},


### PR DESCRIPTION
### This PR is related to user story DST-437

## Description
Fetch a new token if a `MissingTokenError` is raised when refreshing the token.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

