### PR TITLE
Prevent use of internal API's to hinder downtime of 4insight

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/fourinsight/api/appdirs.py
+++ b/fourinsight/api/appdirs.py
@@ -2,6 +2,7 @@
 This code was taken from https://github.com/ActiveState/appdirs (v1.4.4) and
 modified to suit our purposes.
 """
+
 import os
 import sys
 

--- a/fourinsight/api/authenticate.py
+++ b/fourinsight/api/authenticate.py
@@ -193,6 +193,18 @@ class BaseAuthSession(OAuth2Session, metaclass=ABCMeta):
         response = super().request(*args, **kwargs)
         return response
 
+    def get(self, *args, **kwargs):
+        """
+        Extend the ``requests_oauthlib.OAuth2Session.get`` method
+        to ensure that internal API are not accessed.
+        """
+        url = args[0]
+        if "internal" in url:
+            raise ValueError(
+                "The Internal API is exclusively intended for internal use within 4insight. If you require access to the internal API, kindly reach out to 4insight support."
+            )
+        return super().get(*args, **kwargs)
+
     def get_pages(self, url, **kwargs):
         r"""
         Sends GET requests, and returns a generator that lets the user iterate over

--- a/fourinsight/api/authenticate.py
+++ b/fourinsight/api/authenticate.py
@@ -198,7 +198,7 @@ class BaseAuthSession(OAuth2Session, metaclass=ABCMeta):
         Extend the ``requests_oauthlib.OAuth2Session.get`` method
         to ensure that internal API are not accessed.
         """
-        url = args[0]
+        url = args[0] if args else kwargs.get("url", None)
         if "internal" in url:
             raise ValueError(
                 "The Internal API is exclusively intended for internal use within 4insight. If you require access to the internal API, kindly reach out to 4insight support."


### PR DESCRIPTION
### This PR is related to user story [ESS-2426](https://4insight.atlassian.net/browse/ESS-2426)

## Description
To regulate python's use of internal API's to prevent downtime of 4insight. For now, it is not included in the user guide. This is coordinated with Nikolai and Heidi. 

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  



[ESS-2426]: https://4insight.atlassian.net/browse/ESS-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ